### PR TITLE
Update documentation with correct keyword argument syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,23 @@ julia --project test/test_transport.jl
 julia --project test/test_integration.jl
 ```
 
+### Documentation
+
+After making code changes, update the documentation:
+
+```bash
+# Update documentation files in docs/src/ if needed
+# Key files:
+# - docs/src/index.md - Main landing page
+# - docs/src/getting-started.md - Installation and basic usage
+# - docs/src/examples.md - Comprehensive usage examples
+# - docs/src/api.md - API reference (auto-generated from docstrings)
+
+# Note: All documentation examples use keyword argument syntax:
+# query(prompt="...", options=options) - CORRECT
+# query("...") - INCORRECT (will cause MethodError)
+```
+
 ### Example Usage
 ```bash
 # Run example files
@@ -93,7 +110,7 @@ This is an **unofficial** Julia SDK for Claude Code that **fully mirrors** the P
 
 ### Test Files Structure:
 1. **`test/test_types.jl`** - Message types, options configuration, content blocks
-2. **`test/test_errors.jl`** - Error hierarchy, exception handling, string representations  
+2. **`test/test_errors.jl`** - Error hierarchy, exception handling, string representations
 3. **`test/test_client.jl`** - Query function, message processing, client configuration
 4. **`test/test_transport.jl`** - CLI discovery, command building, JSON streaming, process management
 5. **`test/test_integration.jl`** - End-to-end testing, CLI integration, comprehensive scenarios
@@ -127,10 +144,12 @@ Tests gracefully handle CLI availability:
 
 ## API Usage Examples
 
+**IMPORTANT**: Always use keyword arguments with the `query` function:
+
 ```julia
 using ClaudeCodeSDK
 
-# Basic usage
+# ✅ CORRECT: Basic usage with keyword arguments
 for message in query(prompt="What is 2 + 2?")
     if message isa AssistantMessage
         for block in message.content
@@ -140,6 +159,9 @@ for message in query(prompt="What is 2 + 2?")
         end
     end
 end
+
+# ❌ INCORRECT: This will cause MethodError
+# query("What is 2 + 2?")  # Don't do this!
 
 # Advanced configuration
 options = ClaudeCodeOptions(
@@ -162,6 +184,11 @@ end
 
 ## Status: ✅ Complete
 
+✅ **Recent Updates:**
+- **Documentation Fixed**: All examples now use correct keyword argument syntax (`query(prompt="...")`)
+- **CLI-Aware Demo Fixed**: All example files run without method errors
+- **Documentation Updated**: docs/src/ files updated with proper API usage patterns
+
 The Julia SDK now provides **full feature parity** with the Python SDK:
 
 1. ✅ **API Compatibility**: Exact same function signatures and behavior
@@ -177,7 +204,7 @@ The Julia SDK now provides **full feature parity** with the Python SDK:
 
 ### Test Suite Highlights:
 - **Complete Python Test Port**: All test files from `claude-code-sdk-python/tests/` successfully ported
-- **5 Test Files**: `test_types.jl`, `test_errors.jl`, `test_client.jl`, `test_transport.jl`, `test_integration.jl`  
+- **5 Test Files**: `test_types.jl`, `test_errors.jl`, `test_client.jl`, `test_transport.jl`, `test_integration.jl`
 - **288 Total Tests**: Comprehensive coverage matching Python SDK exactly
 - **100% Pass Rate**: All tests consistently pass ✅
 - **CLI Adaptive**: Tests intelligently handle CLI availability

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -10,7 +10,7 @@ This page contains various usage examples for ClaudeCodeSDK.jl.
 using ClaudeCodeSDK
 
 # Basic query
-result = query("What is 2 + 2?")
+result = query(prompt="What is 2 + 2?")
 for message in result
     if message isa AssistantMessage
         for block in message.content
@@ -32,7 +32,7 @@ options = ClaudeCodeOptions(
     system_prompt="You are a helpful math tutor. Explain your reasoning step by step."
 )
 
-result = query("How do you solve 2x + 5 = 13?", options=options)
+result = query(prompt="How do you solve 2x + 5 = 13?", options=options)
 for message in result
     if message isa AssistantMessage
         for block in message.content
@@ -57,7 +57,7 @@ options = ClaudeCodeOptions(
     allowed_tools=["Read", "Write"]
 )
 
-result = query("List the files in the current directory", options=options)
+result = query(prompt="List the files in the current directory", options=options)
 ```
 
 ### Model Selection
@@ -70,7 +70,7 @@ options = ClaudeCodeOptions(
     model="claude-3-5-sonnet-20241022"
 )
 
-result = query("Write a haiku about programming", options=options)
+result = query(prompt="Write a haiku about programming", options=options)
 ```
 
 ### Permission Modes
@@ -84,7 +84,7 @@ options = ClaudeCodeOptions(
     permission_mode="acceptEdits"
 )
 
-result = query("Create a hello.jl file with a simple greeting", options=options)
+result = query(prompt="Create a hello.jl file with a simple greeting", options=options)
 ```
 
 ## Advanced Examples
@@ -101,11 +101,11 @@ options = ClaudeCodeOptions(
 )
 
 # First query
-result1 = query("Help me write a function to calculate fibonacci numbers", options=options)
+result1 = query(prompt="Help me write a function to calculate fibonacci numbers", options=options)
 
 # Process response and continue conversation
 # Note: Currently each query is independent - conversation state is maintained by Claude CLI
-result2 = query("Can you optimize that fibonacci function?", options=options)
+result2 = query(prompt="Can you optimize that fibonacci function?", options=options)
 ```
 
 ### Tool Usage with Error Handling
@@ -120,7 +120,7 @@ options = ClaudeCodeOptions(
 )
 
 try
-    result = query("Read the contents of README.md and summarize it", options=options)
+    result = query(prompt="Read the contents of README.md and summarize it", options=options)
     
     for message in result
         if message isa AssistantMessage
@@ -162,7 +162,7 @@ options = ClaudeCodeOptions(
 )
 
 # Ask for code review
-result = query("Please review the code in src/ClaudeCodeSDK.jl and suggest improvements", options=options)
+result = query(prompt="Please review the code in src/ClaudeCodeSDK.jl and suggest improvements", options=options)
 
 for message in result
     if message isa AssistantMessage
@@ -186,7 +186,7 @@ using ClaudeCodeSDK
 function is_cli_available()
     try
         # Simple test query
-        result = query("test")
+        result = query(prompt="test")
         return true
     catch e
         if e isa CLINotFoundError
@@ -199,7 +199,7 @@ end
 
 if is_cli_available()
     println("Claude CLI is available")
-    result = query("Hello Claude!")
+    result = query(prompt="Hello Claude!")
 else
     println("Claude CLI not found. Please install it first.")
 end
@@ -251,7 +251,7 @@ queries = [
 for query_text in queries
     println("\\n=== $query_text ===")
     try
-        result = query(query_text, options=options)
+        result = query(prompt=query_text, options=options)
         for message in result
             if message isa AssistantMessage
                 for block in message.content
@@ -279,7 +279,7 @@ options = ClaudeCodeOptions(
     cwd=pwd()
 )
 
-result = query("Read the source files and generate API documentation in Markdown format", options=options)
+result = query(prompt="Read the source files and generate API documentation in Markdown format", options=options)
 
 for message in result
     if message isa AssistantMessage

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -31,7 +31,7 @@ julia --project -e "using Pkg; Pkg.instantiate()"
 using ClaudeCodeSDK
 
 # Basic query - returns Vector{Message}
-result = query("Hello Claude")
+result = query(prompt="Hello Claude")
 for message in result
     if message isa AssistantMessage
         for block in message.content
@@ -55,7 +55,7 @@ options = ClaudeCodeOptions(
 )
 
 # Query with options
-result = query("Tell me a joke", options=options)
+result = query(prompt="Tell me a joke", options=options)
 for message in result
     if message isa AssistantMessage
         for block in message.content
@@ -88,7 +88,7 @@ options = ClaudeCodeOptions(
     cwd="/path/to/project"
 )
 
-result = query("Help me with my project", options=options)
+result = query(prompt="Help me with my project", options=options)
 ```
 
 ## Running Tests
@@ -123,7 +123,7 @@ Always wrap your queries in try-catch blocks for robust error handling:
 using ClaudeCodeSDK
 
 try
-    result = query("Hello")
+    result = query(prompt="Hello")
     for message in result
         println(message)
     end

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -98,6 +98,28 @@ for message in query(
 end
 ```
 
+## Recent Updates
+
+✅ **CLI-Aware Demo Fixed**: All example files now work correctly with proper keyword argument syntax.
+
+## Available Examples
+
+The repository includes several runnable examples:
+
+```bash
+# Basic usage with all features
+julia --project examples/quick_start.jl
+
+# JSON streaming and message processing demo  
+julia --project examples/streaming_demo.jl
+
+# Tool execution without CLI dependency
+julia --project examples/tool_execution_demo.jl
+
+# CLI-aware functionality with error handling
+julia --project examples/cli_aware_demo.jl
+```
+
 ## Next Steps
 
 - [Getting Started Guide](getting-started.md)


### PR DESCRIPTION
## Summary
- Update all documentation examples to use proper `query(prompt="...")` syntax
- Fix CLAUDE.md with comprehensive documentation guidelines
- Add clear warnings about correct vs incorrect API usage patterns
- Document recent CLI-aware demo fixes and updates

## Changes Made
- **docs/src/examples.md**: Updated 13 query() calls to use keyword arguments
- **docs/src/getting-started.md**: Fixed 4 query() examples with proper syntax
- **docs/src/index.md**: Added recent updates section and example descriptions
- **CLAUDE.md**: Added documentation guidelines and API usage warnings

## Key Improvements
- All examples now consistently use `query(prompt="...", options=options)` syntax
- Clear visual indicators (✅/❌) for correct vs incorrect usage
- Comprehensive documentation guidelines for future contributors
- Prevention of MethodError issues for users following documentation

## Test plan
- [x] All documentation examples use consistent keyword argument syntax
- [x] CLAUDE.md includes clear guidance about proper API usage
- [x] Documentation reflects the fixes made to CLI-aware demo
- [x] Visual indicators help users avoid common mistakes

🤖 Generated with [Claude Code](https://claude.ai/code)