### PR TITLE
Fix README.md examples to use keyword argument syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ julia --project examples/cli_aware_demo.jl
 using ClaudeCodeSDK
 
 # Simple query - returns Vector{Message}
-result = query("Hello Claude")
+result = query(prompt="Hello Claude")
 for message in result
     if message isa AssistantMessage
         for block in message.content
@@ -247,7 +247,7 @@ This Julia SDK follows a modular design with:
 using ClaudeCodeSDK
 
 try
-    result = query("Hello")
+    result = query(prompt="Hello")
     for message in result
         println(message)
     end


### PR DESCRIPTION
## Summary
- Update remaining examples in README.md to use correct keyword argument syntax
- Change `query("...")` to `query(prompt="...")` in Basic Query and Error Handling sections
- Ensures consistency with API documentation and prevents MethodError

## Test plan
- [x] Verify examples use consistent keyword argument syntax
- [x] Check that all README examples match CLAUDE.md guidance
- [x] Confirm changes maintain documentation clarity

🤖 Generated with [Claude Code](https://claude.ai/code)