### PR TITLE
Update repository URLs and fix minor formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package is currently in development. To use it:
 
 ```bash
 # Clone the repository
-git clone <repository-url>
+git clone https://github.com/AtelierArith/ClaudeCodeSDK.jl.git
 cd ClaudeCodeSDK.jl
 
 # Install dependencies
@@ -270,7 +270,7 @@ See [src/errors.jl](src/errors.jl) for the complete exception hierarchy.
 
 ### Test Files Structure:
 1. **`test/test_types.jl`** - Message types, options configuration, content blocks
-2. **`test/test_errors.jl`** - Error hierarchy, exception handling, string representations  
+2. **`test/test_errors.jl`** - Error hierarchy, exception handling, string representations
 3. **`test/test_client.jl`** - Query function, message processing, client configuration
 4. **`test/test_transport.jl`** - CLI discovery, command building, JSON streaming, process management
 5. **`test/test_integration.jl`** - End-to-end testing, CLI integration, comprehensive scenarios

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -16,7 +16,7 @@ Since the package is in development, you'll need to clone and set it up locally:
 
 ```bash
 # Clone the repository
-git clone <repository-url>
+git clone https://github.com/AtelierArith/ClaudeCodeSDK.jl.git
 cd ClaudeCodeSDK.jl
 
 # Install dependencies

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -33,7 +33,7 @@ This package is currently in development. To use it:
 
 ```bash
 # Clone the repository
-git clone <repository-url>
+git clone https://github.com/AtelierArith/ClaudeCodeSDK.jl.git
 cd ClaudeCodeSDK.jl
 
 # Install dependencies
@@ -110,7 +110,7 @@ The repository includes several runnable examples:
 # Basic usage with all features
 julia --project examples/quick_start.jl
 
-# JSON streaming and message processing demo  
+# JSON streaming and message processing demo
 julia --project examples/streaming_demo.jl
 
 # Tool execution without CLI dependency


### PR DESCRIPTION
## Summary
- Replace placeholder `<repository-url>` with actual GitHub URL in documentation
- Fix trailing whitespace issues in documentation files  
- Ensure consistent formatting across README and docs

## Test plan
- [x] Verify documentation builds correctly
- [x] Check all repository URLs are accessible
- [x] Ensure no formatting issues remain

🤖 Generated with [Claude Code](https://claude.ai/code)